### PR TITLE
Fixed bug in 'free shipping for certain products'

### DIFF
--- a/Shipping/Free shipping for certain products/script.rb
+++ b/Shipping/Free shipping for certain products/script.rb
@@ -1,6 +1,6 @@
 FREE_TAG = 'freeship'
 
-if Input.cart.shipping_address.country_code == 'US' && Input.cart.line_items.any?{|item| item.variant.product.tags.include? FREE_TAG}
+if Input.cart.shipping_address.country_code == 'US' && Input.cart.line_items.all?{|item| item.variant.product.tags.include? FREE_TAG}
   Input.shipping_rates.each do |shipping_rate|
     next if shipping_rate.price == Money.zero
     shipping_rate.apply_discount(shipping_rate.price, message: "Free Shipping!")


### PR DESCRIPTION
The script was using any? but it needed to use all? in order to verify all the line items had the tag before adding free shipping.

The original implementation caused a bug where only 1 line item needed the tag.

Bug reported here: #10 